### PR TITLE
Unlock sounds on mobile devices

### DIFF
--- a/src/howler.core.js
+++ b/src/howler.core.js
@@ -180,12 +180,16 @@
           self.mobileAutoEnable = false;
 
           // Remove the touch start listener.
+          document.removeEventListener('touchstart', unlock, true);
           document.removeEventListener('touchend', unlock, true);
+          document.removeEventListener('click', unlock, true);
         };
       };
 
       // Setup a touch start listener to attempt an unlock in.
+      document.addEventListener('touchstart', unlock, true);
       document.addEventListener('touchend', unlock, true);
+      document.addEventListener('click', unlock, true);
 
       return self;
     },


### PR DESCRIPTION
This is linked to https://github.com/ornicar/lila/issues/8852.  On mobile safari move sounds were sometimes not being activated until after a tap interaction.

This fix (seen on the original Howler branch too) listens to more touch events in order to unlock the play sounds.